### PR TITLE
fixed the nonexistent reviews bug

### DIFF
--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -264,7 +264,11 @@ export default function Home({ authStatus, authenticate, currentUser }) {
           ...bookLayout,
           payload: appLayout.payload,
         })
-        setBookMeta(response.data[0].reviews);
+        if (response.data[0] !== undefined) {
+          setBookMeta(response.data[0].reviews);
+        } else {
+          setBookMeta([])
+        }
       })
   }
 


### PR DESCRIPTION
When there was no metadata for a given book it would leave previously rendered metadata unchanged...fixed so that the page renders with an empty review set as expected for new books